### PR TITLE
Update README.md and layers.py for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A PyTorch version will be released later.
 1. OpenAI Baselines
 2. rllab (commit number `b3a2899`)
 3. MuJoCo (1.5)
-4. TensorFlow (>= 1.9)
+4. TensorFlow (>= 1.9 and <=1.13.2)
 5. NumPy (>= 1.14.5)
 6. Python 3.6
 

--- a/lunzi/nn/layers.py
+++ b/lunzi/nn/layers.py
@@ -17,7 +17,7 @@ class Linear(Module):
         self.use_bias = bias
         with self.scope:
             self.op_input = tf.placeholder(dtype=tf.float32, shape=[None, in_features], name='input')
-            self.weight = Parameter(weight_initializer([in_features, out_features]), name='weight')
+            self.weight = Parameter(weight_initializer([in_features, out_features], tf.float32), name='weight')
             if bias:
                 self.bias = Parameter(tf.zeros([out_features], dtype=tf.float32), name='bias')
 


### PR DESCRIPTION
I want to resolve  issue #4 with this small commit. 

`baselines.baselines.common.tf_util.normc_initializer._initializer(.)` has a `None` default argument for `dtype`. Thus, not setting the argument would be a runtime error.

Tensorflow 1.14.0 removed almost all the methods which are being patched in `slbo.lunzi.nn.patch.monkey_patch()`. README is updated to reflect this. 

